### PR TITLE
Add 'random-card' page with a list of cards to pick from.

### DIFF
--- a/src/assets/index.css
+++ b/src/assets/index.css
@@ -21,7 +21,9 @@ div.wgf-card {
   align-items: center;
   width: 100%;
 }
+
 div.wgf-card-content {
+  width: 100%;
   max-width: 35em;
 }
 

--- a/templates/about_index.html
+++ b/templates/about_index.html
@@ -1,6 +1,13 @@
 {% extends "card.html" %}
+{# This Source Code Form is subject to the terms of the Mozilla Public
+   License, v. 2.0. If a copy of the MPL was not distributed with this
+   file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
+
 {% block card_title %}{{_('About Who Goes First?')}}{% endblock %}
 {% block card_body %}
+<img src="/static/cards/who_goes_first.png"
+  class="pixel-art wgf-card-image">
+
   <p>{{_('Have you played a board game but didn\'t like the recommended way to
   choose the first player? Is your gaming group bored with throwing dice
   to choose? Who Goes First is a new way to choose the first player.')}}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+{# This Source Code Form is subject to the terms of the Mozilla Public
+   License, v. 2.0. If a copy of the MPL was not distributed with this
+   file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{% block card_title %}{% endblock %}</title>
+<link rel="stylesheet" href="/static/index.css" type="text/css">
+{% for lang in translations %}
+<link rel="alternate"
+    hreflang="{{ lang }}"
+    href="{{ translations[lang]['url'] }}">
+{% endfor %}
+
+<label for="wgf-menu-toggle" id="wgf-menu-toggle-label">
+  <img src="/static/icons/menu.svg" alt="Toggle menu" id="wgf-menu-toggle-icon">
+</label>
+<input type="checkbox" id="wgf-menu-toggle"></input>
+<div id="wgf-menu">
+  <ul>
+  {% for lang in translations|sort %}
+    <li>
+      <a href="{{ translations[lang]['url'] }}">{{ translations[lang]['name'] }}</a>
+    </li>
+  {% endfor %}
+  </ul>
+</div>
+
+<div class="wgf-card">
+  {% block base_body %}
+  {% endblock %}
+</div>
+
+<div class="footer">
+  <!--
+    TODO: Add links to help translate and contribute to this open-source
+        project.
+        See: https://github.com/bananajuicellc/who-goes-first/issues/22
+  -->
+</div>
+
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+  ga('create', '{{ google_analytics_id }}', 'auto');
+  ga('send', 'pageview');
+</script>

--- a/templates/card.html
+++ b/templates/card.html
@@ -1,67 +1,30 @@
-<!DOCTYPE html>
-<meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<title>{% block card_title %}{% endblock %}</title>
-<link rel="stylesheet" href="/static/index.css" type="text/css">
-{% for lang in translations %}
-<link rel="alternate"
-    hreflang="{{ lang }}"
-    href="{{ translations[lang]['url'] }}">
-{% endfor %}
-
-<label for="wgf-menu-toggle" id="wgf-menu-toggle-label">
-  <img src="/static/icons/menu.svg" alt="Toggle menu" id="wgf-menu-toggle-icon">
-</label>
-<input type="checkbox" id="wgf-menu-toggle"></input>
-<div id="wgf-menu">
-  <ul>
-  {% for lang in translations|sort %}
-    <li>
-      <a href="{{ translations[lang]['url'] }}">{{ translations[lang]['name'] }}</a>
-    </li>
-  {% endfor %}
-  </ul>
-</div>
+{% extends "base.html" %}
+{# This Source Code Form is subject to the terms of the Mozilla Public
+   License, v. 2.0. If a copy of the MPL was not distributed with this
+   file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
 
 {% set is_about_card = request.endpoint.startswith('about_') %}
 
-<div class="wgf-card">
-  <div id="wgf-card-content" class="wgf-card-content">
-    {% block card_body %}
-    {% endblock %}
-  </div>
-  {% if is_about_card %}
-    {# len('about_') == 6, so we remove that to get to the card #}
-    <p><a href="{{ url_for(request.endpoint[6:]) }}">
-      {{_('Back to the card.')}}
-    </a>
-  {% else %}
-    <div id="wgf-next-button">
-      <a href="/random-card/">
-      <img id="wgf-next-button-img"
+{% block base_body %}
+<div id="wgf-card-content" class="wgf-card-content">
+{% block card_body %}
+{% endblock %}
+</div>
+
+{% if is_about_card %}
+  {# len('about_') == 6, so we remove that to get to the card #}
+  <p><a href="{{ url_for(request.endpoint[6:]) }}">
+  {{_('Back to the card.')}}
+  </a>
+{% else %}
+  <div id="wgf-next-button">
+    <a href="/{{g.language}}/{{global_translations[g.language]['translations']['random-card']}}/">
+    <img id="wgf-next-button-img"
         src="/static/buttons/arrow_right.svg" alt="{{_('Get the next card.')}}">
-      </a>
-    </div>
-    <p><a href="{{ url_for('about_' + request.endpoint) }}">
-      {{_('About this card.')}}
     </a>
-  {% endif %}
-</div>
-
-<div class="footer">
-  <!--
-    TODO: Add links to help translate and contribute to this open-source
-        project.
-        See: https://github.com/bananajuicellc/who-goes-first/issues/22
-  -->
-</div>
-
-<script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-  ga('create', '{{ google_analytics_id }}', 'auto');
-  ga('send', 'pageview');
-</script>
+  </div>
+  <p><a href="{{ url_for('about_' + request.endpoint) }}">
+  {{_('About this card.')}}
+  </a>
+{% endif %}
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,4 +1,7 @@
 {% extends "card.html" %}
+{# This Source Code Form is subject to the terms of the Mozilla Public
+   License, v. 2.0. If a copy of the MPL was not distributed with this
+   file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
 
 {% block card_title %}{{_('Who Goes First?')}}{% endblock %}
 

--- a/templates/random_card.html
+++ b/templates/random_card.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+{# This Source Code Form is subject to the terms of the Mozilla Public
+   License, v. 2.0. If a copy of the MPL was not distributed with this
+   file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
+
+{% block card_title %}{{_('Choose a random card.')}}{% endblock %}
+
+{% block base_body %}
+<div id="wgf-card-content" class="wgf-card-content">
+
+<h1>{{_('Choose a random card.')}}</h1>
+
+<ul>
+{% for card in cards | sort %}
+  {% if g.language in cards[card] %}
+    {% set translated_card = cards[card][g.language] %}
+  {% else %}
+    {% set translated_card = cards[card]['en'] %}
+  {% endif %}
+
+  <li><a href="{{translated_card['url']}}">{{translated_card['name']}}</a></li>
+{% endfor %}
+</ul>
+
+<p>{{_('You probably reached this page because JavaScript was disabled. Enable
+JavaScript to make the "next card" arrow automatically go to a random card.')}}
+
+</div>
+{% endblock %}

--- a/translations/fr/LC_MESSAGES/messages.po
+++ b/translations/fr/LC_MESSAGES/messages.po
@@ -7,31 +7,36 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-07-17 18:43-0700\n"
+"POT-Creation-Date: 2016-07-24 02:05+0000\n"
 "PO-Revision-Date: 2016-07-17 18:44-0700\n"
 "Last-Translator: \n"
 "Language: fr\n"
 "Language-Team: fr <LL@li.org>\n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"Plural-Forms: nplurals=2; plural=(n > 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.3.4\n"
-"X-Generator: Poedit 1.8.8\n"
 
 #: templates/about_award.html:3
 msgid "About the award card."
 msgstr "À propos de la carte prix."
 
-#: templates/about_award.html:13
+#: templates/about_award.html:13 templates/about_baking.html:13
+#: templates/about_batteries.html:13 templates/about_birthday.html:13
+#: templates/about_building.html:13 templates/about_stung.html:13
+#: templates/about_train.html:13
 msgid ""
 "This card was drawn by <a href=\"http://www.timswast.com\"\n"
 "  rel=\"author\">Tim Swast</a>."
 msgstr ""
-"Cette carte a été dessinée par <a href=\"http://www.timswast.com\" rel="
-"\"author\">Tim Swast</a>."
+"Cette carte a été dessinée par <a href=\"http://www.timswast.com\" "
+"rel=\"author\">Tim Swast</a>."
 
-#: templates/about_award.html:20
+#: templates/about_award.html:20 templates/about_baking.html:20
+#: templates/about_batteries.html:20 templates/about_birthday.html:20
+#: templates/about_building.html:20 templates/about_stung.html:20
+#: templates/about_train.html:20
 msgid ""
 "This work is licensed under a\n"
 "<a rel=\"license\" about=\"/static/cards/award.gif\"\n"
@@ -42,27 +47,41 @@ msgstr ""
 "href=\"https://creativecommons.org/licenses/by/4.0/\">Licence Creative "
 "Commons Attribution 4.0 International</a>."
 
-#: templates/about_index.html:2
+#: templates/about_baking.html:3
+msgid "About the baking card."
+msgstr ""
+
+#: templates/about_batteries.html:3
+msgid "About the batteries card."
+msgstr ""
+
+#: templates/about_birthday.html:3
+msgid "About the birthday card."
+msgstr ""
+
+#: templates/about_building.html:3
+msgid "About the building card."
+msgstr ""
+
+#: templates/about_index.html:6
 msgid "About Who Goes First?"
 msgstr "Sur qui va d’abord ?"
 
-#: templates/about_index.html:4
+#: templates/about_index.html:11
 msgid ""
 "Have you played a board game but didn't like the recommended way to\n"
-"  choose the first player? Is your gaming group bored with throwing "
-"dice\n"
+"  choose the first player? Is your gaming group bored with throwing dice\n"
 "  to choose? Who Goes First is a new way to choose the first player."
 msgstr ""
 "Avez-vous joué à une planche de jeu, mais n’aimait pas la méthode "
-"recommandée pour choisir le premier joueur ? Votre groupe de jeu "
-"s’ennuie avec lancer de dés pour choisir ? Qui va d’abord est une "
-"nouvelle façon de choisir le premier joueur."
+"recommandée pour choisir le premier joueur ? Votre groupe de jeu s’ennuie"
+" avec lancer de dés pour choisir ? Qui va d’abord est une nouvelle façon "
+"de choisir le premier joueur."
 
-#: templates/about_index.html:8
+#: templates/about_index.html:15
 msgid ""
 "Open it and get a random card. It could be interactive or have your\n"
-"  friends tell the best story. Use it to pick the next player, or if "
-"you\n"
+"  friends tell the best story. Use it to pick the next player, or if you\n"
 "  don't like it: tap the arrow to get a new card."
 msgstr ""
 "Ouvrez-le et obtenez une carte aléatoire. Il peut être interactif ou ou "
@@ -70,25 +89,47 @@ msgstr ""
 "prochain joueur, ou si vous ne l’aimez : Appuyez sur la flèche pour "
 "obtenir une nouvelle carte."
 
-#: templates/about_index.html:13
+#: templates/about_index.html:20
 msgid ""
 "Subscribe to our <a href=\"http://tinyletter.com/whogoesfirst\">mailing\n"
 "  list</a> to be the first to find out about updates like new cards."
 msgstr ""
-"Abonnez-vous à notre <a href=\"http://tinyletter.com/whogoesfirst"
-"\">liste d’envoi</a> pour être le premier à connaître les mises à jour "
-"comme nouvelles cartes."
+"Abonnez-vous à notre <a href=\"http://tinyletter.com/whogoesfirst\">liste"
+" d’envoi</a> pour être le premier à connaître les mises à jour comme "
+"nouvelles cartes."
 
-#: templates/about_index.html:17
+#: templates/about_index.html:24
 msgid ""
 "Who Goes First is a project of\n"
 "  <a href=\"http://www.timswast.com\">Timothy</a> and\n"
 "  <a href=\"http://swast.net/alexandra/\">Alexandra Swast</a> and our\n"
 "  friends, born out of our love for board games."
 msgstr ""
-"Qui va tout d’abord est un projet de <a href=\"http://www.timswast.com"
-"\">Timothy</a> et <a href=\"http://swast.net/alexandra/\">Alexandra "
-"Swast</a> et nos amis, nées de notre amour pour les jeux de société."
+"Qui va tout d’abord est un projet de <a "
+"href=\"http://www.timswast.com\">Timothy</a> et <a "
+"href=\"http://swast.net/alexandra/\">Alexandra Swast</a> et nos amis, "
+"nées de notre amour pour les jeux de société."
+
+#: templates/about_oldest_movie.html:3
+msgid "About the oldest movie card."
+msgstr ""
+
+#: templates/about_oldest_movie.html:19
+msgid ""
+"This work (<span property=\"dct:title\">Blacksmith Scene</span>, by\n"
+"<a href=\"https://en.wikipedia.org/wiki/Blacksmith_Scene\" "
+"rel=\"dct:creator\"><span\n"
+"  property=\"dct:title\">William K.L. Dickson under the employ of Thomas\n"
+"Edison</span></a>) is free of known copyright restrictions."
+msgstr ""
+
+#: templates/about_stung.html:3
+msgid "About the stung card."
+msgstr ""
+
+#: templates/about_train.html:3
+msgid "About the train card."
+msgstr ""
 
 #: templates/award.html:3
 msgid "Award card."
@@ -98,25 +139,103 @@ msgstr "Carte prix."
 msgid "The player who most recently won an award goes first."
 msgstr "Le joueur qui a récemment remporté un prix va d'abord."
 
-#: templates/card.html:36
+#: templates/baking.html:3
+msgid "Baking card."
+msgstr ""
+
+#: templates/baking.html:8
+msgid "The player who most recently baked something goes first."
+msgstr ""
+
+#: templates/batteries.html:3
+msgid "Batteries card."
+msgstr ""
+
+#: templates/batteries.html:8
+msgid ""
+"The player who most recently changed the batteries in something goes\n"
+"first."
+msgstr ""
+
+#: templates/birthday.html:3
+msgid "Birthday card."
+msgstr ""
+
+#: templates/birthday.html:8
+msgid "The player whose birthday is nearest to today goes first."
+msgstr ""
+
+#: templates/building.html:3
+msgid "Building card."
+msgstr ""
+
+#: templates/building.html:8
+msgid "The player who most recently built something goes first."
+msgstr ""
+
+#: templates/card.html:17
 msgid "Back to the card."
 msgstr "Retour à la carte."
 
-#: templates/card.html:42
+#: templates/card.html:23
 msgid "Get the next card."
 msgstr "Obtenez la carte suivante."
 
-#: templates/card.html:46
+#: templates/card.html:27
 msgid "About this card."
 msgstr "À propos de cette carte."
 
-#: templates/index.html:3
+#: templates/index.html:6
 msgid "Who Goes First?"
 msgstr "Qui va d’abord ?"
 
-#: templates/index.html:9
+#: templates/index.html:12
 msgid "Click the arrow to find out who goes first."
 msgstr "Cliquez sur la flèche pour savoir qui va d’abord."
 
+#: templates/oldest_movie.html:3
+msgid "Oldest movie card."
+msgstr ""
+
+#: templates/oldest_movie.html:8
+msgid ""
+"Have every player say the movie they most recently watched. Whoever\n"
+"watched the oldest one goes first."
+msgstr ""
+
+#: templates/random_card.html:6 templates/random_card.html:11
+msgid "Choose a random card."
+msgstr "Choisissez une carte aléatoire."
+
+#: templates/random_card.html:25
+msgid ""
+"You probably reached this page because JavaScript was disabled. Enable\n"
+"JavaScript to make the \"next card\" arrow automatically go to a random "
+"card."
+msgstr "Vous avez probablement atteint cette page parce que JavaScript est désactivé. Activer\n"
+"JavaScript pour rendre le \"carte suivante\" flèche aller automatiquement à un aléatoire"
+"carte."
+
+#: templates/stung.html:3
+msgid "Stung card."
+msgstr ""
+
+#: templates/stung.html:8
+msgid "The player who was most recently stung by an insect goes first."
+msgstr ""
+
+#: templates/train.html:3
+msgid "Train card."
+msgstr ""
+
+#: templates/train.html:8
+msgid ""
+"The player who most recently rode a train goes first. Alternatively,\n"
+"each player shares an experience they had relating to trains. The player "
+"with\n"
+"the most interesting story goes first."
+msgstr ""
+
 #~ msgid "The player who last won and award goes first."
 #~ msgstr "Le joueur qui a récemment remporté un prix va d'abord."
+


### PR DESCRIPTION
This fixes the broken link in the 'next card' arrow button on all
pages. The page will work with or without JavaScript. I hope to
catch the link event when JavaScript is enabled and go to the next
card in a deck stored in local storage (like how the Chrome / mobile
app works).

Also, makes a slight change to index.css to make the image size the
same on the about page as it is on the main page. The width wasn't
wide enough when there wasn't a full line of text.

Adds translations for the random card page.

![Picking a "random" card.](https://drive.google.com/uc?id=0B3Y1GivFBYKOT0E4RTBHRWRKUWM)