### PR TITLE
Add stack trace to promises output.

### DIFF
--- a/src/assets/js/index.js
+++ b/src/assets/js/index.js
@@ -15,9 +15,9 @@ document.addEventListener(
     // TODO: make path to root relative
     wgf.listCards({rootPath: '', preferredLanguage: CURRENT_LANGUAGE})
       .then(wgf.getDeck)
-      .then(
-        wgf.attachNextCard,
+      .then(wgf.attachNextCard)
+      .catch(
         function (error) {
-          console.error('Failed to load the deck.', error)
+          console.error('Failed to load the deck.\n', error, '\n', error.stack)
         })
   })


### PR DESCRIPTION
This makes it much easier to debug when there are problems.

Before:

```
index.js:21 Failed to load the deck. TypeError: Cannot read property 'keys' of undefined(…)
```

After:

```
index.js:21 Failed to load the deck.
TypeError: Cannot read property 'keys' of undefined(…)
TypeError: Cannot read property 'keys' of undefined
     at wgf.getDeck
     (http://localhost:8080/static/js/wgf.js:73:28)(anonymous function)
     @ index.js:21
```

Corresponding GIF (not a selfie this time):

[![Can I peek into this error message?](https://drive.google.com/uc?id=0B3Y1GivFBYKORjBoVmYweTA3ZlU)](http://www.planetary.org/multimedia/video/bill-nye-reaction-gifs.html)

(Peeking into an error to see more information.)

Fixes #32 