### PR TITLE
Add help and contribute pages.

### DIFF
--- a/static/index.css
+++ b/static/index.css
@@ -20,6 +20,7 @@ div.wgf-card {
   flex-flow: column;
   align-items: center;
   width: 100%;
+  min-height: 80%;
 }
 
 div.wgf-card-content {

--- a/templates/base/base.html
+++ b/templates/base/base.html
@@ -34,12 +34,15 @@
 </div>
 
 <div class="wgf-footer">
-  <a href="/{{g.language}}/privacy/">{{_('Privacy')}}</a>
-  <!--
-    TODO: Add links to help translate and contribute to this open-source
-        project.
-        See: https://github.com/bananajuicellc/who-goes-first/issues/22
-  -->
+  {{_('Who Goes First is free and open source. It\'s not free to run, though.
+  Consider <a href="/en/contribute/">contributing</a> to the project.' | safe)}}
+
+  <p>© Who Goes First
+  <a href="https://github.com/whogoesfirst/who-goes-first/commit/0579f2821e8c1e4496782170b91a1cfcb9e883d8">2015</a>-2016
+  | <a href="/{{g.language}}/">{{_('Home')}}</a>
+  | <a href="/{{g.language}}/privacy/">{{_('Privacy')}}</a>
+  | <a href="/{{g.language}}/contribute/">{{_('Contribute')}}</a>
+  | <a href="/{{g.language}}/help/">{{_('Help')}}</a>
 </div>
 
 <script>

--- a/templates/contribute.html
+++ b/templates/contribute.html
@@ -1,0 +1,28 @@
+{% extends "base/base.html" %}
+{# This Source Code Form is subject to the terms of the Mozilla Public
+   License, v. 2.0. If a copy of the MPL was not distributed with this
+   file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
+
+{% block card_title %}{{_('Contribute')}}{% endblock %}
+
+{% block base_body %}
+<div id="wgf-card-content" class="wgf-card-content">
+
+<h1>{{_('Contributing to Who Goes First')}}</h1>
+
+<p>{{_('Here are some ways you can help:')}}
+
+<ul>
+  <li><a href="https://gratipay.com/Who-Goes-First/">{{_('Donate money to help
+    pay for development and hosting.')}}</a></li>
+  <li><a href="https://github.com/whogoesfirst/who-goes-first/blob/master/docs/ADDING_CARDS.md">
+    {{_('Submit an idea for a new card.')}}</a></li>
+  <li><a href="https://github.com/whogoesfirst/who-goes-first/issues/new">
+    {{_('Report a problem.')}}</a></li>
+  <li><a href="https://github.com/whogoesfirst/who-goes-first/blob/master/docs/TRANSLATING.md">
+    {{_('Translate Who Goes First to your language.')}}</a></li>
+  <li><a href="https://github.com/whogoesfirst/who-goes-first/blob/master/CONTRIBUTING.md">
+    {{_('Code a new feature or bug fix.')}}</a></li>
+</ul>
+</div>
+{% endblock %}

--- a/templates/help.html
+++ b/templates/help.html
@@ -1,0 +1,22 @@
+{% extends "base/base.html" %}
+{# This Source Code Form is subject to the terms of the Mozilla Public
+   License, v. 2.0. If a copy of the MPL was not distributed with this
+   file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
+
+{% block card_title %}{{_('Help')}}{% endblock %}
+
+{% block base_body %}
+<div id="wgf-card-content" class="wgf-card-content">
+
+<h1>{{_('Help')}}</h1>
+
+<p>{{_('Having trouble with Who Goes First?')}}
+
+<ul>
+  <li><a href="https://github.com/whogoesfirst/who-goes-first/issues/new">
+    {{_('Report a problem on the public issue tracker.')}}</a></li>
+  <li><a href="mailto:support@whogoes1st.com">
+    {{_('Contact us privately via email.')}}</a></li>
+</ul>
+</div>
+{% endblock %}

--- a/translations/fr/LC_MESSAGES/messages.po
+++ b/translations/fr/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-10-01 12:59-0700\n"
+"POT-Creation-Date: 2016-10-13 19:42-0700\n"
 "PO-Revision-Date: 2016-08-13 16:55-0700\n"
 "Last-Translator: \n"
 "Language: fr\n"
@@ -64,6 +64,56 @@ msgstr ""
 "href=\"http://www.timswast.com\">Timothy</a> et <a "
 "href=\"http://swast.net/alexandra/\">Alexandra Swast</a> et nos amis, "
 "nées de notre amour pour les jeux de société."
+
+#: templates/base/base.html:44 templates/contribute.html:6
+msgid "Contribute"
+msgstr ""
+
+#: templates/contribute.html:11
+msgid "Contributing to Who Goes First"
+msgstr ""
+
+#: templates/contribute.html:13
+msgid "Here are some ways you can help:"
+msgstr ""
+
+#: templates/contribute.html:16
+msgid ""
+"Donate money to help\n"
+"    pay for development and hosting."
+msgstr ""
+
+#: templates/contribute.html:19
+msgid "Submit an idea for a new card."
+msgstr ""
+
+#: templates/contribute.html:21
+msgid "Report a problem."
+msgstr ""
+
+#: templates/contribute.html:23
+msgid "Translate Who Goes First to your language."
+msgstr ""
+
+#: templates/contribute.html:25
+msgid "Code a new feature or bug fix."
+msgstr ""
+
+#: templates/base/base.html:45 templates/help.html:6 templates/help.html:11
+msgid "Help"
+msgstr ""
+
+#: templates/help.html:13
+msgid "Having trouble with Who Goes First?"
+msgstr ""
+
+#: templates/help.html:17
+msgid "Report a problem on the public issue tracker."
+msgstr ""
+
+#: templates/help.html:19
+msgid "Contact us privately via email."
+msgstr ""
 
 #: templates/index.html:6
 msgid "Who Goes First?"
@@ -170,7 +220,11 @@ msgstr ""
 "JavaScript pour rendre le \"carte suivante\" flèche aller automatiquement"
 " à un aléatoirecarte."
 
-#: templates/base/base.html:37
+#: templates/base/base.html:42
+msgid "Home"
+msgstr ""
+
+#: templates/base/base.html:43
 msgid "Privacy"
 msgstr ""
 

--- a/translations/uk/LC_MESSAGES/messages.po
+++ b/translations/uk/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-10-01 12:59-0700\n"
+"POT-Creation-Date: 2016-10-13 19:42-0700\n"
 "PO-Revision-Date: 2016-09-18 15:05-0700\n"
 "Last-Translator: \n"
 "Language: uk\n"
@@ -64,6 +64,56 @@ msgstr ""
 "Хто йде в першу чергу це проект <a href=\"http://www.timswast.com\"> "
 "Тімоті </a> і <a href=\"http://swast.net/alexandra/\"> Олександра "
 "Swast</a> і наш друзів, народилася з нашої любові до настільні ігри."
+
+#: templates/base/base.html:44 templates/contribute.html:6
+msgid "Contribute"
+msgstr ""
+
+#: templates/contribute.html:11
+msgid "Contributing to Who Goes First"
+msgstr ""
+
+#: templates/contribute.html:13
+msgid "Here are some ways you can help:"
+msgstr ""
+
+#: templates/contribute.html:16
+msgid ""
+"Donate money to help\n"
+"    pay for development and hosting."
+msgstr ""
+
+#: templates/contribute.html:19
+msgid "Submit an idea for a new card."
+msgstr ""
+
+#: templates/contribute.html:21
+msgid "Report a problem."
+msgstr ""
+
+#: templates/contribute.html:23
+msgid "Translate Who Goes First to your language."
+msgstr ""
+
+#: templates/contribute.html:25
+msgid "Code a new feature or bug fix."
+msgstr ""
+
+#: templates/base/base.html:45 templates/help.html:6 templates/help.html:11
+msgid "Help"
+msgstr ""
+
+#: templates/help.html:13
+msgid "Having trouble with Who Goes First?"
+msgstr ""
+
+#: templates/help.html:17
+msgid "Report a problem on the public issue tracker."
+msgstr ""
+
+#: templates/help.html:19
+msgid "Contact us privately via email."
+msgstr ""
 
 #: templates/index.html:6
 msgid "Who Goes First?"
@@ -194,7 +244,11 @@ msgstr ""
 "відключений. Увімкніть JavaScript, щоб зробити \"наступна картка\" "
 "стрілка автоматично переходить на випадкову картку."
 
-#: templates/base/base.html:37
+#: templates/base/base.html:42
+msgid "Home"
+msgstr ""
+
+#: templates/base/base.html:43
 msgid "Privacy"
 msgstr "Приватність"
 

--- a/whogoesfirst.py
+++ b/whogoesfirst.py
@@ -225,11 +225,25 @@ def index_card():
     return render_template('index.html')
 
 
+@app.route('/en/contribute/', endpoint='contribute_en')
+@app.route('/fr/contribute/', endpoint='contribute_fr')
+@app.route('/uk/contribute/', endpoint='contribute_uk')
+def handle_contribute():
+    return render_template('contribute.html')
+
+
 @app.route('/en/privacy/', endpoint='privacy_en')
 @app.route('/fr/privacy/', endpoint='privacy_fr')
 @app.route('/uk/privacy/', endpoint='privacy_uk')
 def handle_privacy():
     return render_template('privacy.html')
+
+
+@app.route('/en/help/', endpoint='help_en')
+@app.route('/fr/help/', endpoint='help_fr')
+@app.route('/uk/help/', endpoint='help_uk')
+def handle_help():
+    return render_template('help.html')
 
 
 @app.route('/en/about/', endpoint='about_index_en')


### PR DESCRIPTION
Who Goes First players did not know how to help out the project. Now
they have a handy link to contribute. Also, if they were having a
problem, there wasn't a linked way to get help. Now there's a handy help
link. (Maybe I should put some FAQs on that page, too? Ha, I guess wait
until I get some Qs before I have any FAQs. :-) )

![I don't know if the head bob dance is helping, but I think it's helping me.](https://drive.google.com/uc?id=0B3Y1GivFBYKOcDllNTdqR1k4WEU)